### PR TITLE
Fix CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,35 @@
 name: CI
 
-on: [push]
+# Events that trigger this workflow
+on: [push, pull_request]
 
 jobs:
+  lint:
+    name: Lint source code
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - name: Checkout 📥
+        uses: actions/checkout@v2.3.4
+      - name: Setup Node 💿
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14
+
+      - name: Restore npm cache ♻️
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install development dependencies 📚
+        run: npm ci
+      - name: Check code style 📑
+        run: npm run style:ci
+      - name: Run Linter 📑
+        run: npm run lint
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,13 @@
 
 name: Lint
 
-on: push
+# Events that trigger this workflow
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   run-linters:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: Test and Coverage
 
+# Events that trigger this workflow
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
 Fix workflows so that external contributors can submit changes without repository secrets

Please see: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/